### PR TITLE
Fix closing address

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1978,7 +1978,7 @@ function maybeShowMap(model) {
                         maxZoom: 19,
                         attribution: '&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
                       }).addTo(self.mapHandle);
-                self.popUpHandle = L.popup({closeButton: false}).setLatLng([0.0, 0,0]).openOn(self.mapHandle);
+                self.popUpHandle = L.popup({closeButton: false, autoClose: false, closeOnEscapeKey: false, closeOnClick: false}).setLatLng([0.0, 0,0]).openOn(self.mapHandle);
                 self.popUpHandle
             }
             const resource = data.resource[0];


### PR DESCRIPTION
It used to be that if you clicked around the map then the address pop-up would close and never come back, even if you tried to open up other resources in the map. We've tried to disable this.

![image](https://user-images.githubusercontent.com/79415431/112901725-1cb37200-90b3-11eb-9028-0e21e151c73b.png)
