### PR TITLE
Don't try to show a map if geocoding failed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1462,8 +1462,8 @@ self.gqlResourceDataToNode = (resource) => {
     const geocodeSuccess = "🔵 ";
 
     if (resource.geocode && resource.geocode.startsWith(geocodeSuccess)) {
-	const geoJsonRaw = resource.geocode.substring(geocodeSuccess.length);
-	const geoJson = JSON.parse(atob(geoJsonRaw));
+        const geoJsonRaw = resource.geocode.substring(geocodeSuccess.length);
+        const geoJson = JSON.parse(atob(geoJsonRaw));
 
         node.lat = geoJson.o.lat;
         node.lng = geoJson.o.lng;
@@ -1978,8 +1978,8 @@ function maybeShowMap(model) {
 
             if (!resourceNode.lat) {
                 alert("Resource has an invalid location, sorry!");
-		return;
-	    }
+                return;
+            }
 
             self.mapModalOpen();
             self.mapHandle.invalidateSize(false);

--- a/src/index.js
+++ b/src/index.js
@@ -1449,33 +1449,25 @@ self.CreateTextNode = (desiredText)=>{
 
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-self.gqlResourceDataToNode = (resource)=>{
-    const geoJsonRaw = resource.geocode.substring(3);
-    const geoJson = JSON.parse(atob(geoJsonRaw));
-
-    var node = {
+self.gqlResourceDataToNode = (resource) => {
+    const node = {
         "id": resource.id,
         "type": "dimo-node",
         "class": "[Resource]",
         "label": resource.name,
         "location": resource.location,
-        "lat": geoJson.o.lat,
-        "lng": geoJson.o.lng,
         "airtableURL": "https://airtable.com/tblAKJHMkBTTAbuXE/viwfjiEW7MrdgTysI/" + resource.id,
     };
+
+    const geocodeSuccess = "🔵 ";
+
+    if (resource.geocode && resource.geocode.startsWith(geocodeSuccess)) {
+	const geoJsonRaw = resource.geocode.substring(geocodeSuccess.length);
+	const geoJson = JSON.parse(atob(geoJsonRaw));
+
+        node.lat = geoJson.o.lat;
+        node.lng = geoJson.o.lng;
+    }
 
     if (resource.resource_resource_types.length) {
 
@@ -1983,6 +1975,12 @@ function maybeShowMap(model) {
             }
             const resource = data.resource[0];
             const resourceNode = self.gqlResourceDataToNode(resource);
+
+            if (!resourceNode.lat) {
+                alert("Resource has an invalid location, sorry!");
+		return;
+	    }
+
             self.mapModalOpen();
             self.mapHandle.invalidateSize(false);
             self.mapHandle.setView([resourceNode.lat, resourceNode.lng], 13);


### PR DESCRIPTION
We would crash if you tried to use "Show in Map" on a resource for which geocoding failed; now we just display an alert. [Try 36 Methyl St out](https://graph.dimo.zone?resource_id=recqp7r6zu5FaxXwZ).

![image](https://user-images.githubusercontent.com/79415431/113464558-8a390880-93fb-11eb-8f5d-6fa16ee5eff0.png)

The geocode field has this weird `"🔵 "` prefix if it's valid, so we just look for that.
